### PR TITLE
- ajout du scope quelque soit le niveau d'habilitation

### DIFF
--- a/user.go
+++ b/user.go
@@ -46,14 +46,14 @@ func (user User) getRoles() Roles {
 	if strings.EqualFold("b", user.niveau) {
 		roles.add("dgefp")
 	}
-	if user.niveau != "0" {
+	if strings.EqualFold("a", user.niveau) || strings.EqualFold("b", user.niveau) {
 		roles.add("score", "detection", "pge")
 		if user.accesGeographique != "" {
 			roles.add(user.accesGeographique)
 		}
-		if !(len(user.scope) == 1 && user.scope[0] == "") {
-			roles.add(user.scope...)
-		}
+	}
+	if !(len(user.scope) == 1 && user.scope[0] == "") {
+		roles.add(user.scope...)
 	}
 	return roles
 }

--- a/user_test.go
+++ b/user_test.go
@@ -27,17 +27,25 @@ func TestUser_roles_with_niveau_b(t *testing.T) {
 func TestUser_roles_with_scopes(t *testing.T) {
 	ass := assert.New(t)
 	scopes := []string{"first", "second"}
-	user := User{scope: scopes}
+	user := User{niveau: "0", scope: scopes}
 	actual := user.getRoles()
 
 	ass.Contains(actual, scopes[0])
 	ass.Contains(actual, scopes[1])
 }
 
-func TestUser_roles_with_acces_geographique(t *testing.T) {
+func TestUser_roles_with_acces_geographique_and_niveau_a(t *testing.T) {
 	ass := assert.New(t)
 	accessGeographique := "any where"
-	user := User{accesGeographique: accessGeographique}
+	user := User{niveau: "A", accesGeographique: accessGeographique}
 	actual := user.getRoles()
 	ass.Contains(actual, accessGeographique)
+}
+
+func TestUser_roles_with_acces_geographique_and_niveau_0(t *testing.T) {
+	ass := assert.New(t)
+	accessGeographique := "any where"
+	user := User{niveau: "0", accesGeographique: accessGeographique}
+	actual := user.getRoles()
+	ass.NotContains(actual, accessGeographique)
 }


### PR DESCRIPTION
Le niveau d'habilitation 0 permet de partir d'une habilitation sans aucun rôle, seuls les rôles de la colonne `SCOPE` sont ajoutés dans le profil.

Quelques adaptation pour rendre ce comportement effectif:
- ajout du scope quelque soit le niveau d'habilitation
- zone géographique pour tout niveau != 0 devient ==A || ==B
- précision des test